### PR TITLE
Logs component

### DIFF
--- a/server/deploy_config.py
+++ b/server/deploy_config.py
@@ -20,6 +20,7 @@ class Config:
     checkpoint_dir = os.getenv("CHECKPOINT_DIR", "checkpoints")
     output_dir = os.getenv("OUTPUT_DIR", "outputs/")
     uploads_dir = os.getenv("UPLOADS_DIR", "uploads/")
+    log_file = os.getenv("LOG_FILE", "output.log")
     num_gpus = int(os.environ.get("NUM_GPU", 1))
     factory_module = os.getenv("FACTORY_MODULE", "cosmos_transfer1.diffusion.inference.transfer_pipeline")
     factory_function = os.getenv("FACTORY_FUNCTION", "create_transfer_pipeline")

--- a/server/gradio_app.py
+++ b/server/gradio_app.py
@@ -21,6 +21,7 @@ from cosmos_transfer1.utils import log
 from server.deploy_config import Config
 import gradio as gr
 from server import gradio_file_server
+from server import gradio_log_file_viewer
 from server.model_factory import create_pipeline
 
 
@@ -150,6 +151,8 @@ def create_gradio_interface():
                 output_video = gr.Video(label="Generated Video", height=400)
                 status_text = gr.Textbox(label="Status", lines=5, interactive=False)
                 generate_btn = gr.Button("Generate Video", variant="primary", size="lg")
+
+        gradio_log_file_viewer.log_file_viewer(log_file=Config.log_file, num_lines=100, update_interval=1)
 
         generate_btn.click(
             fn=infer_wrapper,

--- a/server/gradio_log_file_viewer.py
+++ b/server/gradio_log_file_viewer.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from server.deploy_config import Config
+import gradio as gr
+
+
+def _tail_file(file_path: str, num_lines: int) -> str:
+    """
+    Reads the last `num_lines` lines from a file and returns them as a string.
+    - Uses a seek-based approach to read only the last `num_lines` lines of the file.
+    - So, performance shouldn't be affected by file size like it would be with readlines().
+    """
+    try:
+        with open(file_path, "rb") as f:
+            total_lines_wanted = num_lines
+
+            BLOCK_SIZE = 1024
+            f.seek(0, 2)
+            block_end_byte = f.tell()
+            lines_to_go = total_lines_wanted
+            block_number = -1
+            blocks = []
+            while lines_to_go > 0 and block_end_byte > 0:
+                if (block_end_byte - BLOCK_SIZE > 0):
+                    f.seek(block_number*BLOCK_SIZE, 2)
+                    blocks.append(f.read(BLOCK_SIZE))
+                else:
+                    f.seek(0,0)
+                    blocks.append(f.read(block_end_byte))
+                lines_found = blocks[-1].count(b'\n')
+                lines_to_go -= lines_found
+                block_end_byte -= BLOCK_SIZE
+                block_number -= 1
+            all_read_text = b''.join(reversed(blocks))
+            # Decode bytes to string and return
+            text = all_read_text.decode('utf-8', errors='replace')
+            return '\n'.join(text.splitlines()[-total_lines_wanted:])
+    except FileNotFoundError:
+        return f"Log file not found: {file_path}"
+    except Exception as e:
+        return f"Error reading log file: {e}"
+
+def log_file_viewer(
+    log_file: str = Config.log_file,
+    num_lines: int = 100,
+    update_interval: float = 1,
+) -> str:
+    """
+    Gradio component that renders the final `num_lines` lines of a log file, updating periodically.
+
+    Args:
+        log_file (str): The path to the log file.
+        num_lines (int): The number of lines to read from the log file.
+        update_interval (float): The interval in seconds at which to update the log file.
+
+    Returns:
+        gr.Textbox: Textbox component that displays the tail of the log file.
+    """
+
+    def _tail_logs() -> str:
+        return _tail_file(log_file, num_lines)
+
+    # Use timer.tick() to update the log file, as gr.Textbox(every=...) reveals the API endpoint.
+    timer = gr.Timer(value=update_interval, active=True)
+    logs = gr.Textbox(label="Logs", interactive=False, lines=30, autoscroll=True, value=_tail_logs())
+    timer.tick(fn=_tail_logs, outputs=logs, api_name=False)
+
+    return logs


### PR DESCRIPTION
### Summary
Very basic logging component.
* Output from gradio server is piped to a file via `tee`, e.g.: `PYTHONPATH=. python server/gradio_app.py 2>&1 | tee -a /mnt/pvc/gradio/logs/output.log`
* Periodically (every second), the gradio app reads the final 100 lines from the log file and outputs them in a textbox.
* For efficiency, the read uses `seek` instead of `readlines` which should keep it performant even if the file grows in size.

### Issues
* We use various loggers in the repo that initialize in different places, which made patching them difficult.
* The current setup doesn't organize logs by request. So, there wasn't a good way to limit what logs are shown on the frontend.

### Demo

https://github.com/user-attachments/assets/fafc4fc2-efa4-4de7-8cc3-7705535cb571

