### PR TITLE
Hide api routes for file_server component

### DIFF
--- a/server/gradio_file_server.py
+++ b/server/gradio_file_server.py
@@ -303,16 +303,19 @@ def file_server_components(upload_dir: str, open: bool = True) -> gr.Accordion:
         fn=lambda temp_files: _handle_file_upload_event(temp_files, upload_dir),
         inputs=[file_upload],
         outputs=[upload_status, view_file_dropdown],
+        api_name=False,  # UI only component.
     )
     refresh_btn.click(
         fn=lambda dropdown_value: _handle_refresh_button_click_event(dropdown_value, upload_dir),
         inputs=[view_file_dropdown],
         outputs=[view_file_dropdown],
+        api_name=False,  # UI only component.
     )
     view_file_dropdown.select(
         fn=_handle_view_file_dropdown_select_event,
         inputs=[view_file_dropdown],
         outputs=[output_video, output_image, output_json, output_text],
+        api_name=False,  # UI only component.
     )
 
     return top_level_accordion


### PR DESCRIPTION
### Summary
Sets `api_name=False` on the various file server event listeners so their API routes are hidden.

Python client users can just provide `handle_file(local_path)`. So, this component is only really useful for web-users and the route is irrelevant.

### Testing

<details><summary>Screenshot showing that only the `/infer_wrapper` route is visible.</summary>

<img width="2672" height="1527" alt="Screenshot 2025-07-28 at 12 36 59 PM" src="https://github.com/user-attachments/assets/4c5185d8-94ec-4f78-bd87-8d5403821c8a" />

</details>

<details><summary>Python client code showing the same</summary>

****
```py
(.venv) 2025-07-28 12:53:18 nhayesroth@nhayesroth-mlt:~/workspaces/cosmos-infra[nhr/gradio] $ python
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> from gradio_client import client as gradio_client
>>> client = gradio_client.Client("http://localhost:8080/")
Loaded as API: http://localhost:8080/ ✔
>>> client.view_api()
Client.predict() Usage Info
---------------------------
Named API endpoints: 1

 - predict(request_text, api_name="/infer_wrapper") -> (generated_video, status)
    Parameters:
     - [Textbox] request_text: str (not required, defaults to:   {
  "input_video_path": "assets/example1_input_video.mp4",
  "prompt": "The video captures a stunning, photorealistic scene with remarkable attention to detail, giving it a lifelike appearance that is almost indistinguishable from reality. It appears to be from a high-budget 4K movie, showcasing ultra-high-definition quality with impeccable resolution.",
  "negative_prompt": "The video captures a game playing, with bad crappy graphics and cartoonish frames. It represents a recording of old outdated games. The lighting looks very fake. The textures are very raw and basic. The geometries are very primitive. The images are very pixelated and of poor CG quality. There are many subtitles in the footage. Overall, the video is unrealistic at all.",
  "guidance": 7.0,
  "num_steps": 35,
  "seed": 1,
  "sigma_max": 70.0,
  "blur_strength": "medium",
  "canny_threshold": "medium",
  "edge": {
    "control_weight": 1.0
  }
})  
    Returns:
     - [Video] generated_video: dict(video: filepath, subtitles: filepath | None) 
     - [Textbox] status: str 
```
</details>