### PR TITLE
Make `/upload_file` return a json string + change main api name to `generate_video`

### DIFF
--- a/server/gradio_app.py
+++ b/server/gradio_app.py
@@ -158,6 +158,7 @@ def create_gradio_interface():
             fn=infer_wrapper,
             inputs=[request_input],
             outputs=[output_video, status_text],
+            api_name="generate_video",
         )
 
     return interface

--- a/server/gradio_file_server.py
+++ b/server/gradio_file_server.py
@@ -100,10 +100,13 @@ def _handle_api_file_upload_event(file: str, upload_dir: str) -> typing.Dict[str
 
         filename = os.path.basename(file)
         dest_path = os.path.join(upload_folder, filename)
-
         shutil.copy2(file, dest_path)
         logger.info(f"File uploaded to: {dest_path}")
-        return dest_path
+
+        response = { "path": dest_path }
+        logger.info(f"{response=}")
+        return json.dumps(response)
+
     except Exception as e:
         message = f"Upload error: {e}"
         logger.error(message)


### PR DESCRIPTION
### Summary
1. Make the `/upload_file` route to return a json string
2. Change the main inference function's api_name from `/infer_wrapper` to `/generate_video`